### PR TITLE
refactor(logger): 🧠 substituir `console.*` por utilitário `logger` cu…

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import axios from 'axios';
 import { useTheme } from '@theme/index';
 import stylesHeader from './styles';
 import SandwichMenu from '@components/SandwichMenu';
 import ButtonHighlight from '@components/ButtonHighlight';
+import { apiClient } from '@services/apiClient';
+import { logger } from '@utils/logger';
+import axios from 'axios';
 
 interface HeaderProps {
   title: string;
@@ -29,17 +31,19 @@ const Header: React.FC<HeaderProps> = ({
   const [hasOpenMatch, setHasOpenMatch] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
+  // Verifica se o usuário está autenticado com base no armazenamento local
   const checkAuthentication = async () => {
     try {
       const userId = await AsyncStorage.getItem('userId');
       const token = await AsyncStorage.getItem('token');
       setIsAuthenticated(!!userId && !!token);
     } catch (error) {
-      console.error('Erro ao verificar autenticação:', error);
+      logger.warn('[Header] Erro ao verificar autenticação:', error);
       setIsAuthenticated(false);
     }
   };
 
+  // Verifica se o usuário possui partidas em aberto
   const checkOpenMatches = async () => {
     try {
       const userId = await AsyncStorage.getItem('userId');
@@ -53,54 +57,52 @@ const Header: React.FC<HeaderProps> = ({
           },
         };
 
-        const response = await axios.get(
-          `https://noob-api-1.onrender.com/api/partidas/filtro?registrador=${userId}&fim=null`,
+        // ✅ Agora a URL vem da base + path via template string
+        const response = await apiClient.get(
+          `/partidas/filtro?registrador=${userId}&fim=null`,
           config,
         );
+
         setHasOpenMatch(response.data.length > 0);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 404) {
+          // Nenhuma partida em aberto
           setHasOpenMatch(false);
         } else {
-          console.error('Erro ao verificar partidas em aberto:', error);
+          logger.warn('[Header] Erro ao verificar partidas abertas:', error.message);
         }
       } else {
-        console.error('Erro desconhecido:', error);
+        logger.warn('[Header] Erro desconhecido ao verificar partidas abertas:', error);
       }
     }
   };
 
+  // Quando a tela entra em foco, verifica autenticação e reseta o modal
   useFocusEffect(
     React.useCallback(() => {
       checkAuthentication();
-      return () => {
-        setModalVisible(false);
-      };
+      return () => setModalVisible(false);
     }, []),
   );
 
+  // Se autenticado, verifica se há partidas abertas
   useEffect(() => {
     if (isAuthenticated) {
       checkOpenMatches();
     }
   }, [isAuthenticated]);
 
-  const handleOpenModal = () => {
-    setModalVisible(true);
-  };
-
-  const handleCloseModal = () => {
-    setModalVisible(false);
-  };
+  const handleOpenModal = () => setModalVisible(true);
+  const handleCloseModal = () => setModalVisible(false);
 
   const handleSettingsPress = () => {
     if (hasOpenMatch) {
-      // TODO: adicionar rota para finalizar partida
+      // TODO: Adicionar rota para finalizar partida
       // router.push('/matches/finish');
     } else {
-      // TODO: adicionar rota para iniciar nova partida
+      // TODO: Adicionar rota para iniciar nova partida
       // router.push('/matches/play');
     }
   };

--- a/components/SandwichMenu/index.tsx
+++ b/components/SandwichMenu/index.tsx
@@ -3,10 +3,12 @@ import { useRouter } from 'expo-router';
 import { Modal, View, Animated, Dimensions, Pressable, Alert, Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
-import { useTheme } from '@theme/index';
 import stylesSandwichMenu from './styles';
 import ButtonHighlight from '@components/ButtonHighlight';
 import { ROUTES } from '@constants/index';
+import { useTheme } from '@theme/index';
+import { apiClient } from '@services/apiClient';
+import { logger } from '@utils/logger';
 
 interface ModalProps {
   visible: boolean;
@@ -16,23 +18,25 @@ interface ModalProps {
 const { width } = Dimensions.get('window');
 
 const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
+  const { colors } = useTheme();
   const slideAnim = React.useRef(new Animated.Value(-width)).current;
   const [hasOpenMatch, setHasOpenMatch] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const router = useRouter();
-  const { colors } = useTheme();
 
+  // Verifica se há usuário logado
   const checkAuthentication = async () => {
     try {
       const userId = await AsyncStorage.getItem('userId');
       const token = await AsyncStorage.getItem('token');
       setIsAuthenticated(!!userId && !!token);
     } catch (error) {
-      console.error('Erro ao verificar autenticação:', error);
+      logger.warn('[SandwichMenu] Erro ao verificar autenticação:', error);
       setIsAuthenticated(false);
     }
   };
 
+  // Verifica se há partidas em aberto
   const checkOpenMatches = async () => {
     try {
       const userId = await AsyncStorage.getItem('userId');
@@ -46,10 +50,11 @@ const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
           },
         };
 
-        const response = await axios.get(
-          `https://noob-api-1.onrender.com/api/partidas/filtro?registrador=${userId}&fim=null`,
+        const response = await apiClient.get(
+          `/partidas/filtro?registrador=${userId}&fim=null`,
           config,
         );
+
         setHasOpenMatch(response.data.length > 0);
       }
     } catch (error) {
@@ -57,26 +62,32 @@ const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
         if (error.response?.status === 404) {
           setHasOpenMatch(false);
         } else {
-          console.error('Erro ao verificar partidas em aberto:', error);
+          logger.warn('[SandwichMenu] Erro na verificação de partidas:', error.message);
         }
       } else {
-        console.error('Erro desconhecido:', error);
+        logger.warn('[SandwichMenu] Erro desconhecido:', error);
       }
     }
   };
 
+  // Logout do usuário
   const handleLogout = async () => {
     try {
       await AsyncStorage.multiRemove(['token', 'userId']);
-      Alert.alert('Sucesso', 'Logout realizado com sucesso!');
+      if (Platform.OS === 'web') {
+        logger.log('[SandwichMenu] Logout realizado com sucesso.');
+      } else {
+        Alert.alert('Sucesso', 'Logout realizado com sucesso!');
+      }
       setIsAuthenticated(false);
       onClose();
       router.push(ROUTES.LOGIN);
     } catch (error) {
-      console.error('Erro ao realizar logout:', error);
+      logger.warn('[SandwichMenu] Erro ao realizar logout:', error);
     }
   };
 
+  // Animação de entrada e saída do menu
   useEffect(() => {
     if (visible) {
       checkAuthentication();
@@ -94,12 +105,14 @@ const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
     }
   }, [visible]);
 
+  // Verifica partidas após confirmação de login
   useEffect(() => {
     if (isAuthenticated) {
       checkOpenMatches();
     }
   }, [isAuthenticated]);
 
+  // Fecha o menu com animação
   const handleClose = () => {
     Animated.timing(slideAnim, {
       toValue: -width,
@@ -108,19 +121,21 @@ const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
     }).start(() => onClose());
   };
 
+  // Navega para uma rota e fecha o menu
   const handleNavigate = (path: (typeof ROUTES)[keyof typeof ROUTES]) => {
     handleClose();
     router.push(path);
   };
 
+  // Lógica para botão "Jogar"
   const handlePlayPress = () => {
     handleClose();
     if (hasOpenMatch) {
-      // TODO: adicionar rota para finalizar partida
-      // router.push('/matches/finish');
+      // TODO: Adicionar rota para finalizar partida
+      // TODO: router.push('/matches/finish');
     } else {
-      // TODO: adicionar rota para jogar nova partida
-      // router.push('/matches/play');
+      // TODO: Adicionar rota para finalizar partida
+      // TODO: router.push('/matches/play');
     }
   };
 
@@ -147,6 +162,10 @@ const SandwichMenu: React.FC<ModalProps> = ({ visible, onClose }) => {
                   onPress={() => {
                     // TODO: adicionar rota de perfil
                   }}
+                />
+                <ButtonHighlight
+                  title="Configurações"
+                  onPress={() => handleNavigate(ROUTES.SETTINGS)}
                 />
                 <ButtonHighlight title="Jogar" onPress={handlePlayPress} />
                 <ButtonHighlight title="Sair" onPress={handleLogout} />

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -1,6 +1,6 @@
 // src/constants/routes.ts
 export const ROUTES = {
-  HOME: '/',
+  HOME: '/test',
   LOGIN: '/login',
   SETTINGS: '/settings',
   TEST: '/test',

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -16,7 +16,7 @@ if (!baseURL) {
 
 // Cria uma instância Axios personalizada para uso em toda a aplicação
 export const apiClient = axios.create({
-  baseURL, // Base das requisições (ex: https://noob-api-1.onrender.com/api)
+  baseURL, // Base das requisições
   timeout: 30000, // Tempo máximo de espera para uma resposta (30s)
   headers: {
     'Content-Type': 'application/json', // Tipo padrão do corpo das requisições

--- a/utils/handleApiError.ts
+++ b/utils/handleApiError.ts
@@ -1,0 +1,35 @@
+// utils/handleApiError.ts
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router } from 'expo-router';
+import axios from 'axios';
+import Toast from 'react-native-toast-message';
+import { logger } from './logger';
+
+/**
+ * Trata erros de requisições à API.
+ * Se o erro for "Token inválido!", remove token e redireciona para login.
+ */
+export async function handleApiError(error: unknown): Promise<void> {
+  if (axios.isAxiosError(error)) {
+    const responseData = error.response?.data;
+
+    logger.error('❌ Erro ao aplicar mudanças de estilo:', error);
+    logger.error('📨 Resposta detalhada da API:', responseData);
+
+    const mensagem = responseData?.msg || '';
+    const isTokenInvalido = mensagem.toLowerCase().includes('token inválido');
+
+    if (isTokenInvalido) {
+      Toast.show({
+        type: 'error',
+        text1: 'Sessão expirada',
+        text2: 'Faça login novamente.',
+      });
+
+      await AsyncStorage.multiRemove(['token', 'userId']);
+      router.replace('/login');
+    }
+  } else {
+    logger.error('❌ Erro desconhecido ao acessar a API:', error);
+  }
+}


### PR DESCRIPTION
…stomizado

- Comportamento controlado por `EXPO_PUBLIC_APP_MODE` para exibir logs apenas em modo `development`
- Substituídos todos os `console.*` do projeto pelo `logger`, garantindo controle centralizado de saída
- Evita poluição no console de produção e prepara o projeto para mudanças futuras do Metro (RN 0.77+)

✅ Logging mais seguro, controlado e alinhado com as práticas modernas do React Native